### PR TITLE
A8 Scraping Sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# custom
+*.csv
+*.yml

--- a/asp.yml.sample
+++ b/asp.yml.sample
@@ -1,0 +1,4 @@
+asp:
+  a8:
+    id:
+    password:

--- a/main.rb
+++ b/main.rb
@@ -1,6 +1,34 @@
 require "mechanize"
+require "csv"
+
+asp_info = YAML.load_file("asp.yml")
+
+# For example: A8
+ASP_LOGIN_PAGE = "https://www.a8.net"
+ASP_DATA_PAGE = "https://pub.a8.net/a8v2/asResultReportAction.do?action=dm"
+LOGIN_ID = asp_info["asp"]["a8"]["id"]
+PASSWORD = asp_info["asp"]["a8"]["password"]
 
 agent = Mechanize.new
-page = agent.get("http://google.com")
+agent.user_agent = "Windows Mozilla"
+agent.get(ASP_LOGIN_PAGE) do |page|
+  form = page.form_with(name: "asLogin") do |f|
+    f.login = LOGIN_ID
+    f.passwd = PASSWORD
+  end
+  form.submit
 
-p page
+  _page = agent.get(ASP_DATA_PAGE)
+  table = _page.search(".reportTable1")
+  latest_data = table.search("tr")[1]
+  date = latest_data.search("td")[0].text.gsub(/\r\n|\r|\n|\s|\t/, "")
+  confirmed_count = latest_data.search("td")[1].text.gsub(/\r\n|\r|\n|\s|\t/, "")
+  tax_included = latest_data.search("td")[2].text.gsub(/\r\n|\r|\n|\s|\t/, "")
+  tax_excluded = latest_data.search("td")[3].text.gsub(/\r\n|\r|\n|\s|\t/, "")
+  tax = latest_data.search("td")[4].text.gsub(/\r\n|\r|\n|\s|\t/, "")
+
+  CSV.open("data.csv", "w") do |csv|
+    csv << ["日付", "確定件数", "確定報酬額・税込", "確定報酬額・税別", "確定報酬額・税金"]
+    csv << [date, confirmed_count, tax_included, tax_excluded, tax]
+  end
+end


### PR DESCRIPTION
## 概要
 - A8 の確定情報をスクレイピングで取得
 - csv に出力

## 補足
 - 一旦、yml に id, password を入力して実行させる。

## 実行例
```csv
日付,確定件数,確定報酬額・税込,確定報酬額・税別,確定報酬額・税金
2018年06月,0,0円,0円,0円
```